### PR TITLE
Update VNext image and runtime versions in .env

### DIFF
--- a/vnext/docker/.env
+++ b/vnext/docker/.env
@@ -16,16 +16,16 @@ CUSTOM_COMPONENTS_PATH=./custom-components
 APP_DOMAIN=core
 
 # VNext Orchestrator Image
-VNEXT_ORCHESTRATOR_VERSION=0.0.20
+VNEXT_ORCHESTRATOR_VERSION=0.0.21
 
 # VNext Execution Image  
-VNEXT_EXECUTION_VERSION=0.0.20
+VNEXT_EXECUTION_VERSION=0.0.21
 
 #VNext Init Image
-VNEXT_INIT_VERSION=0.0.20
+VNEXT_INIT_VERSION=0.0.21
 
 # VNext Core Runtime Package Version
-VNEXT_CORE_RUNTIME_VERSION=0.0.15
+VNEXT_CORE_RUNTIME_VERSION=0.0.16
 
 # =============================================================================
 # Dapr Components


### PR DESCRIPTION
Bumped orchestrator, execution, init, and core runtime versions in vnext/docker/.env to ensure deployment uses the latest images and packages.

## Summary by Sourcery

No functional changes are present in this pull request; the diff only shows the vnext/docker/.env file touched without any visible content modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker service component versions to latest releases (Orchestrator 0.0.21, Execution 0.0.21, Init 0.0.21, Core Runtime 0.0.16).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->