### PR TITLE
docs: add Init Service documentation and update README files

### DIFF
--- a/doc/en/README.md
+++ b/doc/en/README.md
@@ -103,6 +103,11 @@ Independent components that perform specific operations within the workflow:
 |-------|------|-------------|
 | **Instance Startup** | [`how-to/start-instance.md`](./how-to/start-instance.md) | Instance lifecycle and component management |
 
+### 🚀 Services
+| Topic | File | Description |
+|-------|------|-------------|
+| **Init Service** | [`services/init-service.md`](./services/init-service.md) | Package deployment, versioning and component management service |
+
 ---
 
 ## 🚀 Quick Start

--- a/doc/en/services/init-service.md
+++ b/doc/en/services/init-service.md
@@ -1,0 +1,332 @@
+# vNext Init Service
+
+vNext Init Service is the central service that manages platform component deployment operations. This service enables developers to deploy their workflow packages to the platform.
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Component Types](#component-types)
+- [Deployment Flow](#deployment-flow)
+- [API Endpoints](#api-endpoints)
+- [Package Publish Examples](#package-publish-examples)
+
+---
+
+## Overview
+
+vNext Init Service performs the following operations:
+
+1. **Package Download**: Downloads packages from NPM or other artifact systems
+2. **Version Creation**: Manages versions with semantic versioning strategy
+3. **Component Deploy**: Deploys all component types to the platform
+
+### How It Works
+
+```mermaid
+graph LR
+    A[Developer] -->|Build & Package| B[NPM Registry]
+    B -->|Download| C[Init Service]
+    C -->|Deploy| D[vNext Platform]
+```
+
+1. The developer's repository is first **built** and packaged
+2. The package is uploaded to **NPM** or any artifact system
+3. The `version` field in `vnext.config.json` is semantically versioned
+4. Init service downloads this package and deploys it to the platform
+
+---
+
+## Component Types
+
+Init Service is used to deploy the following component types:
+
+| Component | Description |
+|-----------|-------------|
+| **flows** | Workflow definitions |
+| **tasks** | Task definitions |
+| **schemas** | Data schema definitions |
+| **extensions** | Extension components |
+| **functions** | Function definitions |
+| **views** | View definitions |
+
+---
+
+## Deployment Flow
+
+### 1. Package Preparation
+
+```bash
+# Build the project
+npm run build
+
+# Create the package
+npm pack
+```
+
+### 2. Versioning
+
+Update the version field in `vnext.config.json`:
+
+```json
+{
+  "name": "my-workflow-package",
+  "version": "1.0.0",
+  "domain": "my-domain"
+}
+```
+
+> **Note**: For detailed information on versioning strategy: [Version Management](../principles/versioning.md)
+
+### 3. Upload to NPM
+
+```bash
+npm publish --registry https://your-registry.com
+```
+
+### 4. Deploy with Init Service
+
+Init service downloads the package and deploys it to the platform using the `/api/v1/definitions/publish` endpoint.
+
+---
+
+## API Endpoints
+
+### Health Check
+
+Checks the health status of the service and platform.
+
+```http
+GET /health
+Accept: application/json
+```
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-01-15T10:30:00Z"
+}
+```
+
+---
+
+### Package Publish
+
+Deploys the package to the platform.
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `packageName` | string | ✅ | NPM package name (e.g., `@my-org/my-workflow-package`) |
+| `version` | string | ✅ | Semantic version (e.g., `1.0.0`) |
+| `appDomain` | string | ❌ | Used for domain replacement |
+| `npmRegistry` | string | ❌ | Custom NPM registry URL |
+| `npmToken` | string | ❌ | Authentication token for private registry |
+
+---
+
+## Package Publish Examples
+
+### Basic Usage
+
+The simplest usage - just package name and version:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0"
+}
+```
+
+---
+
+### With Domain Replacement
+
+To specify the domain where the package will be deployed:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "appDomain": "my-custom-domain"
+}
+```
+
+---
+
+### With Custom NPM Registry
+
+To use a custom NPM registry:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com"
+}
+```
+
+---
+
+### Private Registry (With Token)
+
+Using authentication token for private NPM registry:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com",
+  "npmToken": "your-npm-token-here"
+}
+```
+
+---
+
+### Full Configuration
+
+Comprehensive example with all parameters:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com",
+  "npmToken": "your-npm-token-here",
+  "appDomain": "production"
+}
+```
+
+---
+
+## Definitions Publish Endpoint
+
+The endpoint used to directly deploy platform components. This endpoint is used internally by the init service to upload components to the platform after the package is downloaded.
+
+```http
+POST /api/v1/definitions/publish
+Content-Type: application/json
+```
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | ✅ | Component unique key |
+| `flow` | string | ✅ | Associated flow name |
+| `domain` | string | ✅ | Target domain |
+| `version` | string | ✅ | Semantic version |
+| `tags` | string[] | ❌ | Component tags |
+| `attributes` | object | ✅ | Component content |
+| `data` | array | ❌ | Seed data (initial records) |
+
+**Example Request:**
+
+```json
+{
+  "key": "my-component",
+  "flow": "my-flow",
+  "domain": "my-domain",
+  "version": "1.0.0",
+  "tags": ["production", "v1"],
+  "attributes": {
+    // Component content
+  },
+  "data": [
+    {
+      "key": "seed-record-1",
+      "version": "1.0.0",
+      "tags": ["initial"],
+      "attributes": {}
+    }
+  ]
+}
+```
+
+### Response Codes
+
+#### ✅ 200 OK - Success
+
+Component deployed successfully.
+
+---
+
+#### ⚠️ 400 Bad Request - Validation Error
+
+Returned when component validation fails.
+
+```json
+{
+  "type": "https://httpstatuses.com/400/validation/App/900006",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Component validation failed for type 'sys-flows'",
+  "instance": "/api/v1/definitions/publish",
+  "errors": {
+    "workflow.States": [
+      "Workflow must contain exactly one initial state. Found: 2."
+    ]
+  },
+  "errorCode": "validation.App:900006",
+  "prefix": "validation",
+  "code": "App:900006",
+  "traceId": "00-75d0de9d505f79e60997909aa47bc2ec-a9b2e4f305bff2b6-01"
+}
+```
+
+**Common Validation Errors:**
+- Multiple initial states defined in workflow
+- Required fields missing
+- Invalid component structure
+
+---
+
+#### ❌ 409 Conflict - Version Conflict
+
+Returned when the same version already exists.
+
+```json
+{
+  "type": "https://httpstatuses.com/409/conflict/Instance/100002",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "A record with the same version already exists.",
+  "instance": "/api/v1/definitions/publish",
+  "errorCode": "conflict.Instance:100002",
+  "prefix": "conflict",
+  "code": "Instance:100002",
+  "traceId": "00-cc2fa21cbe77902da014702864c563f8-e62547f41765a292-01"
+}
+```
+
+**Solution:** Update the version field in `vnext.config.json` to create a new version.
+
+---
+
+## Related Documentation
+
+- [Version Management](../principles/versioning.md) - Versioning strategy
+- [Platform Fundamentals](../fundamentals/readme.md) - Platform structure
+- [Domain Topology](../fundamentals/domain-topology.md) - Domain architecture
+

--- a/doc/tr/README.md
+++ b/doc/tr/README.md
@@ -103,6 +103,11 @@ State'ler arasındaki geçişleri yöneten bileşen. Dört farklı tetikleme tü
 |------|-------|----------|
 | **Instance Başlatma** | [`how-to/start-instance.md`](./how-to/start-instance.md) | Instance yaşam döngüsü ve bileşen yönetimi |
 
+### 🚀 Servisler
+| Konu | Dosya | Açıklama |
+|------|-------|----------|
+| **Init Service** | [`services/init-service.md`](./services/init-service.md) | Paket deployment, versiyonlama ve bileşen yönetimi servisi |
+
 ---
 
 ## 🚀 Hızlı Başlangıç

--- a/doc/tr/services/init-service.md
+++ b/doc/tr/services/init-service.md
@@ -1,0 +1,332 @@
+# vNext Init Service
+
+vNext Init Service, platform bileşenlerinin deployment işlemlerini yöneten merkezi servistir. Bu servis, geliştiricilerin hazırladıkları workflow paketlerini platforma deploy etmelerini sağlar.
+
+## 📋 İçindekiler
+
+- [Genel Bakış](#genel-bakış)
+- [Bileşen Türleri](#bileşen-türleri)
+- [Deployment Akışı](#deployment-akışı)
+- [API Endpointleri](#api-endpointleri)
+- [Package Publish Örnekleri](#package-publish-örnekleri)
+
+---
+
+## Genel Bakış
+
+vNext Init Service, aşağıdaki işlemleri gerçekleştirir:
+
+1. **Paket İndirme**: NPM veya diğer artifact sistemlerinden paketleri indirir
+2. **Versiyon Oluşturma**: Semantik versiyonlama stratejisi ile versiyonları yönetir
+3. **Bileşen Deploy**: Tüm bileşen türlerini platforma deploy eder
+
+### Çalışma Yöntemi
+
+```mermaid
+graph LR
+    A[Geliştirici] -->|Build & Package| B[NPM Registry]
+    B -->|Download| C[Init Service]
+    C -->|Deploy| D[vNext Platform]
+```
+
+1. Geliştiricinin platforma deploy etmek istediği repo önce **build** alınarak paketlenir
+2. Paket **NPM** veya herhangi bir artifact sistemine yüklenir
+3. `vnext.config.json` dosyasındaki `version` alanı semantik olarak versiyonlanır
+4. Init service bu paketi indirir ve platforma deploy eder
+
+---
+
+## Bileşen Türleri
+
+Init Service aşağıdaki bileşen türlerini deploy etmek için kullanılır:
+
+| Bileşen | Açıklama |
+|---------|----------|
+| **flows** | İş akışı tanımlamaları |
+| **tasks** | Görev tanımlamaları |
+| **schemas** | Veri şema tanımlamaları |
+| **extensions** | Extension bileşenleri |
+| **functions** | Fonksiyon tanımlamaları |
+| **views** | Görünüm tanımlamaları |
+
+---
+
+## Deployment Akışı
+
+### 1. Paket Hazırlama
+
+```bash
+# Projeyi build edin
+npm run build
+
+# Paketi oluşturun
+npm pack
+```
+
+### 2. Versiyonlama
+
+`vnext.config.json` dosyasında version alanını güncelleyin:
+
+```json
+{
+  "name": "my-workflow-package",
+  "version": "1.0.0",
+  "domain": "my-domain"
+}
+```
+
+> **Not**: Versiyonlama stratejisi için detaylı bilgi: [Versiyon Yönetimi](../principles/versioning.md)
+
+### 3. NPM'e Yükleme
+
+```bash
+npm publish --registry https://your-registry.com
+```
+
+### 4. Init Service ile Deploy
+
+Init service paketi indirir ve `/api/v1/definitions/publish` endpointini kullanarak platforma deploy eder.
+
+---
+
+## API Endpointleri
+
+### Health Check
+
+Servis ve platform sağlık durumunu kontrol eder.
+
+```http
+GET /health
+Accept: application/json
+```
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-01-15T10:30:00Z"
+}
+```
+
+---
+
+### Package Publish
+
+Paketi platforma deploy eder.
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+```
+
+**Request Body:**
+
+| Alan | Tip | Zorunlu | Açıklama |
+|------|-----|---------|----------|
+| `packageName` | string | ✅ | NPM paket adı (örn: `@my-org/my-workflow-package`) |
+| `version` | string | ✅ | Semantik versiyon (örn: `1.0.0`) |
+| `appDomain` | string | ❌ | Domain değiştirme için kullanılır |
+| `npmRegistry` | string | ❌ | Özel NPM registry URL'i |
+| `npmToken` | string | ❌ | Private registry için authentication token |
+
+---
+
+## Package Publish Örnekleri
+
+### Temel Kullanım
+
+En basit kullanım şekli - sadece paket adı ve versiyonu:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0"
+}
+```
+
+---
+
+### Domain Değiştirme ile
+
+Paketin deploy edileceği domain'i belirtmek için:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "appDomain": "my-custom-domain"
+}
+```
+
+---
+
+### Özel NPM Registry ile
+
+Özel bir NPM registry kullanmak için:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com"
+}
+```
+
+---
+
+### Private Registry (Token ile)
+
+Private NPM registry için authentication token ekleyerek:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com",
+  "npmToken": "your-npm-token-here"
+}
+```
+
+---
+
+### Tam Konfigürasyon
+
+Tüm parametreleri içeren kapsamlı örnek:
+
+```http
+POST /api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "1.0.0",
+  "npmRegistry": "https://registry.your-company.com",
+  "npmToken": "your-npm-token-here",
+  "appDomain": "production"
+}
+```
+
+---
+
+## Definitions Publish Endpoint
+
+Platform bileşenlerini doğrudan deploy etmek için kullanılan endpoint. Bu endpoint, init service tarafından paket indirildikten sonra bileşenleri platforma yüklemek için dahili olarak kullanılır.
+
+```http
+POST /api/v1/definitions/publish
+Content-Type: application/json
+```
+
+### Request Body
+
+| Alan | Tip | Zorunlu | Açıklama |
+|------|-----|---------|----------|
+| `key` | string | ✅ | Bileşen benzersiz anahtarı |
+| `flow` | string | ✅ | İlişkili flow adı |
+| `domain` | string | ✅ | Hedef domain |
+| `version` | string | ✅ | Semantik versiyon |
+| `tags` | string[] | ❌ | Bileşen etiketleri |
+| `attributes` | object | ✅ | Bileşen içeriği |
+| `data` | array | ❌ | Seed data (başlangıç verileri) |
+
+**Örnek Request:**
+
+```json
+{
+  "key": "my-component",
+  "flow": "my-flow",
+  "domain": "my-domain",
+  "version": "1.0.0",
+  "tags": ["production", "v1"],
+  "attributes": {
+    // Bileşen içeriği
+  },
+  "data": [
+    {
+      "key": "seed-record-1",
+      "version": "1.0.0",
+      "tags": ["initial"],
+      "attributes": {}
+    }
+  ]
+}
+```
+
+### Response Kodları
+
+#### ✅ 200 OK - Başarılı
+
+Bileşen başarıyla deploy edildi.
+
+---
+
+#### ⚠️ 400 Bad Request - Doğrulama Hatası
+
+Bileşen doğrulaması başarısız olduğunda döner.
+
+```json
+{
+  "type": "https://httpstatuses.com/400/validation/App/900006",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Component validation failed for type 'sys-flows'",
+  "instance": "/api/v1/definitions/publish",
+  "errors": {
+    "workflow.States": [
+      "Workflow must contain exactly one initial state. Found: 2."
+    ]
+  },
+  "errorCode": "validation.App:900006",
+  "prefix": "validation",
+  "code": "App:900006",
+  "traceId": "00-75d0de9d505f79e60997909aa47bc2ec-a9b2e4f305bff2b6-01"
+}
+```
+
+**Yaygın Doğrulama Hataları:**
+- Workflow'da birden fazla initial state tanımlanmış
+- Zorunlu alanlar eksik
+- Geçersiz bileşen yapısı
+
+---
+
+#### ❌ 409 Conflict - Versiyon Çakışması
+
+Aynı versiyon zaten mevcut olduğunda döner.
+
+```json
+{
+  "type": "https://httpstatuses.com/409/conflict/Instance/100002",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "A record with the same version already exists.",
+  "instance": "/api/v1/definitions/publish",
+  "errorCode": "conflict.Instance:100002",
+  "prefix": "conflict",
+  "code": "Instance:100002",
+  "traceId": "00-cc2fa21cbe77902da014702864c563f8-e62547f41765a292-01"
+}
+```
+
+**Çözüm:** `vnext.config.json` dosyasında version alanını güncelleyerek yeni bir versiyon oluşturun.
+
+---
+
+## İlgili Dökümanlar
+
+- [Versiyon Yönetimi](../principles/versioning.md) - Versiyonlama stratejisi
+- [Platform Temelleri](../fundamentals/readme.md) - Platform yapısı
+- [Domain Topolojisi](../fundamentals/domain-topology.md) - Domain mimarisi
+


### PR DESCRIPTION
- Add Init Service documentation in doc/en/services/ and doc/tr/services/
- Add Services section to both EN and TR README files with Init Service links

## Summary by Sourcery

Document the Init Service as a first-class platform component and surface it from the main documentation indexes.

Documentation:
- Add an English Init Service guide covering responsibilities, deployment flow, and API endpoints, including publish examples and error handling.
- Add a Turkish Init Service guide mirroring the English content for localized documentation of deployment and API usage.
- Introduce a Services section in both English and Turkish README files and link to the Init Service documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Init Service documentation detailing deployment workflow, API endpoints for package publishing and health checks, supported component types, versioning process, and practical integration examples.
  * Documentation now available in English and Turkish.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->