### PR TITLE
docs: v0.0.37 release notes and documentation updates

### DIFF
--- a/doc/en/flow/function.md
+++ b/doc/en/flow/function.md
@@ -8,8 +8,9 @@ Function APIs provide system-level operations for workflow instances. These buil
 2. [State Function](#state-function)
 3. [Data Function](#data-function)
 4. [View Function](#view-function)
-5. [Best Practices](#best-practices)
-6. [Related Documentation](#related-documentation)
+5. [Authorization](#authorization)
+6. [Best Practices](#best-practices)
+7. [Related Documentation](#related-documentation)
 
 ## Overview
 
@@ -430,20 +431,31 @@ The system automatically determines whether to return iOS-specific content or th
 
 The function follows this logic to determine which view to return:
 
+1. **Rule-based views**: If the state or transition defines a `views` array (rule-based view selection), the first matching rule determines the view. See [Rule-Based View Selection](./rule-based-view-selection.md) for details.
+2. **Single view / legacy**:
+   - If `transitionKey` is provided: use the transition’s view if defined, otherwise the state view.
+   - If not: use the state view.
+3. **Platform**: If `platform` is provided and the view has a platform override, use that content and display; otherwise use the default.
+4. **Language**: Apply Accept-Language and return the matching label from the view’s labels array.
+
 ```
-1. Is transitionKey provided?
+1. Does state/transition have "views" array (rule-based)?
+   ├─ Yes: Evaluate rules in order; return first matching view (or default entry without rule)
+   └─ No: Continue with single view logic below
+
+2. Is transitionKey provided?
    ├─ Yes: Check if transition has a view defined
    │   ├─ Yes: Use transition view
    │   └─ No: Use state view (or return empty if no state view)
    └─ No: Use state view
 
-2. Is platform provided?
+3. Is platform provided?
    ├─ Yes: Check if view has platform override for this platform
    │   ├─ Yes: Use override content and display settings
    │   └─ No: Use original content and display settings
    └─ No: Use original content and display settings
 
-3. Apply language selection based on Accept-Language header
+4. Apply language selection based on Accept-Language header
    └─ Return appropriate label from view's labels array
 ```
 
@@ -491,6 +503,86 @@ GET /core/workflows/account-opening/instances/123/functions/view?transitionKey=s
 Host: api.example.com
 Accept: application/json
 ```
+
+## Authorization
+
+Workflows can define **roles** and **queryRoles** on functions, flows, states, and transitions. The following system function endpoints expose permissions and authorization checks (v0.0.37+).
+
+### Get Flow Permissions
+
+Returns the roles and queryRoles defined for the flow.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/functions/permissions
+```
+
+**Example response:**
+
+```json
+{
+  "workflow": "account-opening",
+  "queryRoles": [{ "role": "morph-idm.viewer", "grant": "allow" }],
+  "states": [
+    { "key": "account-type-selection", "queryRoles": [] },
+    {
+      "key": "account-details-input",
+      "queryRoles": [
+        { "role": "morph-idm.maker", "grant": "allow" },
+        { "role": "morph-idm.viewer", "grant": "deny" }
+      ]
+    }
+  ],
+  "transitions": [
+    { "key": "initiate-account-opening", "target": "account-type-selection", "roles": [] },
+    {
+      "key": "select-demand-deposit",
+      "target": "account-details-input",
+      "roles": [
+        { "role": "morph-idm.maker", "grant": "allow" },
+        { "role": "morph-idm.initiator", "grant": "allow" }
+      ]
+    }
+  ],
+  "functions": []
+}
+```
+
+### Get Instance Permissions
+
+Same response shape as Get Flow Permissions. When the instance is in a subflow, returns the **subflow’s** permissions (subflows are managed from the parent flow).
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/instances/{instanceId}/functions/permissions
+```
+
+### Flow Authorize
+
+Checks whether the given role is allowed for the given transition (or function) on the flow. Optional `version`; if omitted, latest is used.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/functions/authorize?transitionKey=submit-account-details&role=morph-idm.maker&version=1.0.0
+```
+
+**Response 200:** `{ "allowed": true }`  
+**Response 403:** `{ "allowed": false }`
+
+### Instance Authorize
+
+Same response as Flow Authorize. With `queryRoles=true`, permission is evaluated against the instance’s current state (flow and state queryRoles). For instances in a subflow, the active subflow instance is used.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/instances/{instanceId}/functions/authorize?queryRoles=true&role=morph-idm.viewer
+```
+
+### Authorize Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `role` | The role to check. |
+| `version` | Optional. Flow version; default is latest. |
+| `transitionKey` | Transition to check (transition-level roles). |
+| `functionKey` | Function to check (function-level roles). |
+| `queryRoles` | When true, check flow and state queryRoles for the instance’s current state (and subflow context if applicable). |
 
 ## Best Practices
 

--- a/doc/en/flow/instance-filtering.md
+++ b/doc/en/flow/instance-filtering.md
@@ -32,6 +32,8 @@ Simple key-value format: `field=operator:value`
 
 JSON-based format with logical operator support: `{"field":{"operator":"value"}}`
 
+> **v0.0.37 breaking change:** The filter parameter must be a **single expression** (one JSON object or string). The previous array format `"filter": ["expr1", "expr2"]` is no longer supported. Use a single expression; combine conditions with `and`/`or` inside that expression (e.g. `{"and":[{"status":{"eq":"Active"}},{"attributes.amount":{"gt":"500"}}]}`).
+
 ---
 
 ## Filterable Fields
@@ -91,6 +93,43 @@ The `status` field accepts both code and name:
 | `Completed` | `C` | Instance completed successfully |
 | `Faulted` | `F` | Instance encountered an error |
 | `Passive` | `P` | Instance is passive |
+
+> **v0.0.37:** Filtering on `status` and `state` (currentState) now works correctly in instance queries.
+
+---
+
+## OrderBy / Sort (v0.0.37+)
+
+Instance list and data endpoints support sorting via the `sort` or `orderBy` query parameter.
+
+### Single field
+
+```
+?sort={"field":"createdAt","direction":"desc"}
+?orderBy={"field":"status","direction":"asc"}
+```
+
+### Multiple fields
+
+```
+?sort={"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}
+```
+
+- **direction**: `"asc"` or `"desc"` (case-insensitive). Defaults to `"asc"` if omitted.
+
+### Sortable fields
+
+| Field | Notes |
+|-------|-------|
+| `createdAt` | Creation timestamp |
+| `modifiedAt` | Modification timestamp |
+| `completedAt` | Completion timestamp |
+| `status` | Instance status |
+| `key` | Instance key |
+| `currentState` / `state` | Current state (`state` is alias) |
+| `attributes.fieldName` | JSON path into instance data; nested paths supported (e.g. `attributes.nested.path`) |
+
+Instance columns are applied in the database; ordering by `attributes.*` uses the latest instance data JSON and is subject to the same schema/security as filtering.
 
 ---
 

--- a/doc/en/flow/mapping.md
+++ b/doc/en/flow/mapping.md
@@ -268,6 +268,18 @@ var httpTaskResult = context.TaskResponse["httpTask"];
 var scriptTaskResult = context.TaskResponse["scriptTask"];
 ```
 
+#### CurrentTransition (v0.0.37+)
+Provides access to the **original transition request** (body and headers) in input and transition mappings. Use this when you need transition data in scripts without writing it to instance data (e.g. you process it in transition mapping and still need it later in the same pipeline).
+
+- **Data**: Original transition request body (dynamic).
+- **Header**: Original transition request headers (keys are lowercase).
+
+```csharp
+// Reading original transition request in mapping
+var transitionBody = context.CurrentTransition.Data;
+var authHeader = context.CurrentTransition.Header?.authorization;
+```
+
 ## ScriptResponse Class
 
 `ScriptResponse` is the standard response model returned from mapping interfaces. It carries task audit data, instance merge data, and metadata information.

--- a/doc/en/flow/rule-based-view-selection.md
+++ b/doc/en/flow/rule-based-view-selection.md
@@ -1,0 +1,244 @@
+# Rule-Based View Selection
+
+## Overview
+
+Rule-based view selection allows you to dynamically select different views based on runtime conditions. This feature enables platform-specific UIs, role-based views, and conditional UI rendering without modifying workflow logic.
+
+## Use Cases
+
+- **Platform-specific views**: Show different views for iOS, Android, and Web clients
+- **Role-based views**: Display different interfaces based on user roles
+- **Conditional UI**: Render views based on instance data or state
+- **A/B Testing**: Serve different views based on experiment conditions
+
+## JSON Schema
+
+The `views` property accepts an array of view entries. Each entry can have an optional `rule` that determines when it should be selected.
+
+```json
+{
+  "views": [
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class ViewIosRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            if (context.Headers?[\"x-platform\"] == \"ios\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "my-domain",
+        "key": "ios-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true,
+      "extensions": ["ext1", "ext2"]
+    },
+    {
+      "view": {
+        "domain": "my-domain",
+        "key": "default-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    }
+  ]
+}
+```
+
+## ViewEntry Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `rule` | ScriptCode | No | C# script implementing IConditionMapping for conditional evaluation. If omitted, acts as fallback. |
+| `view` | Reference | Yes | Reference to the view component to load. |
+| `loadData` | boolean | No | Whether to load instance data with the view. Default: false. |
+| `extensions` | string[] | No | List of extensions to execute when this view is selected. |
+
+### Rule (ScriptCode) Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `location` | string | No | Script location. Use `"inline"` for embedded code. |
+| `code` | string | Yes | C# code implementing IConditionMapping interface. |
+| `encoding` | string | No | `"NAT"` for plain text, `"B64"` for Base64 encoded. |
+
+### View (Reference) Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `domain` | string | Yes | Domain where the view is registered. |
+| `key` | string | Yes | Unique key of the view. |
+| `version` | string | Yes | Version of the view (semver format). |
+| `flow` | string | Yes | Flow type, typically `"sys-views"`. |
+
+## Rule Evaluation
+
+### Evaluation Order
+
+1. Views are evaluated **in array order** (first to last)
+2. The **first matching rule** wins and its view is returned
+3. An entry **without a rule** acts as a fallback/default
+4. Always place the default view **last** in the array
+
+### Available ScriptContext Properties
+
+Inside the `Handler` method, you have access to `ScriptContext` with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `context.Headers` | Dictionary | HTTP request headers |
+| `context.QueryParameters` | Dictionary | URL query parameters |
+| `context.Instance.Data` | dynamic | Current instance data |
+| `context.Instance.Key` | string | Instance key |
+| `context.State` | string | Current state key |
+| `context.Transition` | string | Current transition key (if applicable) |
+| `context.CurrentTransition.Data` | dynamic | Original transition request body (v0.0.37+) |
+| `context.CurrentTransition.Header` | dynamic | Original transition request headers (v0.0.37+) |
+
+## Examples
+
+### Example 1: Platform-Based View Selection
+
+Select different views based on the `x-platform` header:
+
+```json
+{
+  "key": "checkout-state",
+  "stateType": 1,
+  "views": [
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class CheckoutIosRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            if (context.Headers?[\"x-platform\"] == \"ios\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "ecommerce",
+        "key": "checkout-ios",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    },
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class CheckoutAndroidRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            if (context.Headers?[\"x-platform\"] == \"android\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "ecommerce",
+        "key": "checkout-android",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    },
+    {
+      "view": {
+        "domain": "ecommerce",
+        "key": "checkout-web",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    }
+  ]
+}
+```
+
+### Example 2: Role-Based View Selection
+
+Show different views based on user role from instance data:
+
+```json
+{
+  "key": "approval-state",
+  "stateType": 2,
+  "views": [
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class ApprovalAdminRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            if (context.Instance.Data.userRole == \"admin\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "hr",
+        "key": "approval-admin-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true,
+      "extensions": ["adminActions"]
+    },
+    {
+      "view": {
+        "domain": "hr",
+        "key": "approval-default-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    }
+  ]
+}
+```
+
+### Example 3: Transition Views
+
+The same `views` array format can be used in transitions:
+
+```json
+{
+  "key": "submit-transition",
+  "target": "review-state",
+  "triggerType": 0,
+  "views": [
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class SubmitMobileRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            string platform = context.Headers?[\"x-platform\"];\n            if (platform == \"ios\" || platform == \"android\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "forms",
+        "key": "submit-mobile-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    },
+    {
+      "view": {
+        "domain": "forms",
+        "key": "submit-desktop-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    }
+  ]
+}
+```
+
+## Best Practices
+
+1. **Always include a default view**: Place an entry without a `rule` at the end of the array as a fallback.
+2. **Order rules from specific to general**: More specific rules should come before general ones.
+3. **Keep rules simple**: Complex logic should be handled in extensions or backend services.
+4. **Use meaningful view keys**: Name views descriptively (e.g., `checkout-ios`, `approval-admin-view`).
+5. **Test all paths**: Ensure each rule path is tested with appropriate conditions.
+
+## Error Handling
+
+- If no rule matches and no default view exists, an error is returned
+- Failed rule evaluation is logged and the next rule is evaluated
+- Invalid rule syntax causes the rule to fail (continues to next)
+
+## Related Documentation
+
+- [View Management](./view.md) - View definition and reference schema
+- [Function APIs](./function.md) - View function endpoint and selection logic
+- [Instance Filtering](./instance-filtering.md) - Query parameter usage
+- [Mapping Guide](./mapping.md) - ScriptContext and mapping interfaces

--- a/doc/en/flow/schema.md
+++ b/doc/en/flow/schema.md
@@ -163,6 +163,29 @@ Validation of data sent to and returned from tasks:
 
 Validation of form data coming from user interfaces.
 
+### 5. Master Schema (Flow-Level) (v0.0.37+)
+
+A flow can reference a **master schema** that validates all instance data for the entire lifetime of the instance. When a master schema is defined at the flow level, every write to instance data is validated against that schema; if validation fails, the instance is stopped.
+
+**Flow-level definition:**
+
+```json
+{
+  "schema": {
+    "key": "token-master",
+    "domain": "morph-idm",
+    "version": "1.0.0",
+    "flow": "sys-schemas"
+  }
+}
+```
+
+**Behavior:**
+
+- If a flow has a `schema` reference, all data added to instance data (from transitions, tasks, mappings, etc.) is validated against the referenced schema.
+- Invalid data causes the instance to be terminated (e.g. faulted or stopped).
+- Use this for flows that must keep instance data within a single, consistent structure (e.g. token or identity data).
+
 ## Type Values
 
 The `attributes.type` property specifies which component type the schema is designed for:

--- a/doc/en/flow/view.md
+++ b/doc/en/flow/view.md
@@ -12,6 +12,7 @@ Views are UI component definitions that represent the visual interface for workf
 6. [Platform Overrides](#platform-overrides)
 7. [Usage Examples](#usage-examples)
 8. [Best Practices](#best-practices)
+9. [Related Documentation](#related-documentation)
 
 ## View Definition
 
@@ -57,6 +58,63 @@ The `Content` property contains the actual UI definition. This can be:
 - HTML templates
 - Component references
 - Custom UI definitions
+
+### View Types (ViewType)
+
+Supported view content types:
+
+| Value | Description |
+|-------|-------------|
+| `Json` (1) | JSON content (e.g. form definitions) |
+| `Html` (2) | HTML content |
+| `Markdown` (3) | Markdown content |
+| `DeepLink` (4) | Deep link URL for navigation (e.g. app scheme) |
+| `Http` (5) | HTTP URL (e.g. external or in-app web) |
+| `URN` (6) | URN for platform flow/transition/continue commands |
+
+For **Http**, **DeepLink**, and **URN** types, the content must be a JSON object with the following shape so it can be extended later:
+
+**Http** – external or web URL with optional binding:
+
+```json
+{
+  "href": "https://example.com/page?s=${param}"
+}
+```
+
+**DeepLink** – app deep link (e.g. custom scheme) with optional binding:
+
+```json
+{
+  "href": "on-burgan://onboarding/${param}"
+}
+```
+
+**URN** – platform command URN with optional binding:
+
+```json
+{
+  "urn": "urn:vnext:flow:continue:credit:overdraft-utilization-subprocess:${utilizationId}"
+}
+```
+
+#### URN Structure
+
+Format: `URN:NAMESPACE:TYPE:COMMAND:DOMAIN:FLOW:INSTANCE:TRANSITION`
+
+| Command | Example | Description |
+|---------|---------|-------------|
+| **start** | `urn:vnext:flow:start:credit:utilization-flow` | Start a flow and navigate to it. |
+| **transition** | `urn:vnext:flow:transition:credit:utilization-flow:39484-38484-3938d:submit` | Call a transition on an instance (no user navigation). |
+| **continue** | `urn:vnext:flow:continue:credit:utilization-flow:39484-38484-3938d` | Continue an instance; state is fetched and a view is required to proceed. |
+
+- **Start**: Starts a flow and navigates the user to it.
+- **Transition**: Executes a transition on a given instance without user-facing navigation.
+- **Continue**: Used to advance an instance; the client must get state and then load the view to continue (view is required).
+
+#### Data Binding
+
+Use the expression `${param}` in `href` or `urn` content. The variable is resolved from a single root that combines instance data and extension data on the client; only root-level properties are supported for binding.
 
 ### Display Property
 
@@ -595,5 +653,6 @@ This enables fast retrieval and reduces database load.
 - [State Management](./state.md) - Understanding workflow states
 - [Transition Management](./transition.md) - Working with transitions
 - [Function APIs](./function.md) - View function endpoint details
+- [Rule-Based View Selection](./rule-based-view-selection.md) - Dynamic view selection by rules (platform, role, data)
 - [Interface Documentation](./interface.md) - Mapping interfaces
 

--- a/doc/tr/flow/function.md
+++ b/doc/tr/flow/function.md
@@ -8,8 +8,9 @@ Function API'leri, workflow instance'ları için sistem seviyesi operasyonlar sa
 2. [State Fonksiyonu](#state-fonksiyonu)
 3. [Data Fonksiyonu](#data-fonksiyonu)
 4. [View Fonksiyonu](#view-fonksiyonu)
-5. [En İyi Uygulamalar](#en-iyi-uygulamalar)
-6. [İlgili Dökümanlar](#ilgili-dökümanlar)
+5. [Yetkilendirme (Authorization)](#yetkilendirme-authorization)
+6. [En İyi Uygulamalar](#en-iyi-uygulamalar)
+7. [İlgili Dökümanlar](#ilgili-dökümanlar)
 
 ## Genel Bakış
 
@@ -430,20 +431,29 @@ Sistem, view tanımına göre iOS'a özel içerik mi yoksa varsayılan içerik m
 
 Fonksiyon, hangi view'ın döndürüleceğini belirlemek için bu mantığı izler:
 
+1. **Kural tabanlı view'lar**: State veya transition bir `views` dizisi (kural tabanlı view seçimi) tanımlıyorsa, ilk eşleşen kural view'ı belirler. Detay için [Kural Tabanlı View Seçimi](./rule-based-view-selection.md) dokümanına bakın.
+2. **Tek view / eski kullanım**: `transitionKey` sağlandıysa transition view'ı (tanımlıysa), değilse state view kullanılır; sağlanmadıysa state view kullanılır.
+3. **Platform**: `platform` sağlandıysa ve view'da platform override varsa o içerik ve display kullanılır; yoksa varsayılan.
+4. **Dil**: Accept-Language uygulanır ve view'ın labels dizisinden uygun etiket döndürülür.
+
 ```
-1. transitionKey sağlandı mı?
+1. State/transition'da "views" dizisi (kural tabanlı) var mı?
+   ├─ Evet: Kuralları sırayla değerlendir; ilk eşleşen view'ı döndür (veya kuralı olmayan varsayılan giriş)
+   └─ Hayır: Aşağıdaki tek view mantığına geç
+
+2. transitionKey sağlandı mı?
    ├─ Evet: Transition'ın tanımlı bir view'ı var mı kontrol et
    │   ├─ Evet: Transition view'ını kullan
    │   └─ Hayır: State view'ını kullan (veya state view yoksa boş döndür)
    └─ Hayır: State view'ını kullan
 
-2. platform sağlandı mı?
+3. platform sağlandı mı?
    ├─ Evet: View'ın bu platform için platform override'ı var mı kontrol et
    │   ├─ Evet: Override içeriğini ve display ayarlarını kullan
    │   └─ Hayır: Orijinal içeriği ve display ayarlarını kullan
    └─ Hayır: Orijinal içeriği ve display ayarlarını kullan
 
-3. Accept-Language header'ına göre dil seçimi uygula
+4. Accept-Language header'ına göre dil seçimi uygula
    └─ View'ın labels dizisinden uygun etiketi döndür
 ```
 
@@ -491,6 +501,86 @@ GET /core/workflows/account-opening/instances/123/functions/view?transitionKey=s
 Host: api.example.com
 Accept: application/json
 ```
+
+## Yetkilendirme (Authorization)
+
+Workflow'larda fonksiyon, flow, state ve transition seviyesinde **roles** ve **queryRoles** tanımlanabilir. Aşağıdaki sistem fonksiyon endpoint'leri yetki bilgilerini ve yetkilendirme kontrolünü sunar (v0.0.37+).
+
+### Get Flow Permissions
+
+Flow için tanımlı roles ve queryRoles bilgisini döner.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/functions/permissions
+```
+
+**Örnek yanıt:**
+
+```json
+{
+  "workflow": "account-opening",
+  "queryRoles": [{ "role": "morph-idm.viewer", "grant": "allow" }],
+  "states": [
+    { "key": "account-type-selection", "queryRoles": [] },
+    {
+      "key": "account-details-input",
+      "queryRoles": [
+        { "role": "morph-idm.maker", "grant": "allow" },
+        { "role": "morph-idm.viewer", "grant": "deny" }
+      ]
+    }
+  ],
+  "transitions": [
+    { "key": "initiate-account-opening", "target": "account-type-selection", "roles": [] },
+    {
+      "key": "select-demand-deposit",
+      "target": "account-details-input",
+      "roles": [
+        { "role": "morph-idm.maker", "grant": "allow" },
+        { "role": "morph-idm.initiator", "grant": "allow" }
+      ]
+    }
+  ],
+  "functions": []
+}
+```
+
+### Get Instance Permissions
+
+Get Flow Permissions ile aynı yanıt yapısı. Instance bir subflow içindeyse **subflow**'un yetkileri döner (subflow'lar ana flow üzerinden yönetilir).
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/instances/{instanceId}/functions/permissions
+```
+
+### Flow Authorize
+
+Verilen rolün, flow üzerinde verilen transition (veya function) için izinli olup olmadığını kontrol eder. İsteğe bağlı `version`; verilmezse latest kullanılır.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/functions/authorize?transitionKey=submit-account-details&role=morph-idm.maker&version=1.0.0
+```
+
+**Yanıt 200:** `{ "allowed": true }`  
+**Yanıt 403:** `{ "allowed": false }`
+
+### Instance Authorize
+
+Flow Authorize ile aynı yanıt. `queryRoles=true` ile yetki, instance'ın mevcut state'ine (flow ve state queryRoles) göre değerlendirilir. Subflow içindeki instance'larda aktif subflow instance kullanılır.
+
+```http
+GET /api/v1/{domain}/workflows/{workflow}/instances/{instanceId}/functions/authorize?queryRoles=true&role=morph-idm.viewer
+```
+
+### Authorize Query Parametreleri
+
+| Parametre | Açıklama |
+|-----------|----------|
+| `role` | Kontrol edilecek rol. |
+| `version` | İsteğe bağlı. Flow versiyonu; varsayılan latest. |
+| `transitionKey` | Kontrol edilecek transition (transition seviye roles). |
+| `functionKey` | Kontrol edilecek fonksiyon (function seviye roles). |
+| `queryRoles` | true ise instance'ın mevcut state'i için flow ve state queryRoles kontrol edilir (subflow bağlamı varsa ona göre). |
 
 ## En İyi Uygulamalar
 
@@ -543,6 +633,7 @@ Accept: application/json
 - [Custom Functions](./custom-function.md) - Kullanıcı tanımlı fonksiyonlar ve Schema Fonksiyonu
 - [Instance Filtreleme](./instance-filtering.md) - GraphQL-stil filtreleme kılavuzu
 - [View Yönetimi](./view.md) - View tanımları ve gösterim stratejileri
+- [Kural Tabanlı View Seçimi](./rule-based-view-selection.md) - Kurallara göre dinamik view seçimi
 - [State Yönetimi](./state.md) - Workflow state'lerini anlama
 - [Transition Yönetimi](./transition.md) - Transition'ları yürütme
 - [Versiyonlama ve ETag](../principles/versioning.md) - ETag pattern detayları

--- a/doc/tr/flow/instance-filtering.md
+++ b/doc/tr/flow/instance-filtering.md
@@ -32,6 +32,8 @@ Basit anahtar-değer formatı: `field=operator:value`
 
 Mantıksal operatör desteği olan JSON tabanlı format: `{"field":{"operator":"value"}}`
 
+> **v0.0.37 breaking change:** Filter parametresi **tek bir ifade** (tek JSON nesnesi veya string) olmalıdır. Önceki dizi formatı `"filter": ["expr1", "expr2"]` artık desteklenmemektedir. Tek ifade kullanın; koşulları bu ifade içinde `and`/`or` ile birleştirin (örn. `{"and":[{"status":{"eq":"Active"}},{"attributes.amount":{"gt":"500"}}]}`).
+
 ---
 
 ## Filtrelenebilir Alanlar
@@ -91,6 +93,43 @@ Instance'ın JSON verisinde saklanan herhangi bir alan `attributes` prefix'i kul
 | `Completed` | `C` | Instance başarıyla tamamlandı |
 | `Faulted` | `F` | Instance hata aldı |
 | `Passive` | `P` | Instance pasif |
+
+> **v0.0.37:** `status` ve `state` (currentState) üzerinde filtreleme artık instance sorgularında doğru çalışmaktadır.
+
+---
+
+## OrderBy / Sort (v0.0.37+)
+
+Instance listesi ve data endpoint'leri `sort` veya `orderBy` query parametresi ile sıralama destekler.
+
+### Tek alan
+
+```
+?sort={"field":"createdAt","direction":"desc"}
+?orderBy={"field":"status","direction":"asc"}
+```
+
+### Çoklu alan
+
+```
+?sort={"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}
+```
+
+- **direction**: `"asc"` veya `"desc"` (büyük/küçük harf duyarsız). Verilmezse varsayılan `"asc"`.
+
+### Sıralanabilir alanlar
+
+| Alan | Notlar |
+|------|--------|
+| `createdAt` | Oluşturulma zamanı |
+| `modifiedAt` | Değiştirilme zamanı |
+| `completedAt` | Tamamlanma zamanı |
+| `status` | Instance durumu |
+| `key` | Instance anahtarı |
+| `currentState` / `state` | Mevcut state (`state` alias) |
+| `attributes.fieldName` | Instance verisine JSON yolu; iç içe yollar desteklenir (örn. `attributes.nested.path`) |
+
+Instance kolonları veritabanında uygulanır; `attributes.*` sıralaması en güncel instance verisi JSON'u kullanır ve filtreleme ile aynı şema/güvenlik kurallarına tabidir.
 
 ---
 

--- a/doc/tr/flow/mapping.md
+++ b/doc/tr/flow/mapping.md
@@ -268,6 +268,18 @@ var httpTaskResult = context.TaskResponse["httpTask"];
 var scriptTaskResult = context.TaskResponse["scriptTask"];
 ```
 
+#### CurrentTransition (v0.0.37+)
+Input ve transition mapping'lerde **orijinal transition isteğinin** (body ve headers) erişimini sağlar. Transition verisini instance data'ya yazmadan script'lerde kullanmanız gerektiğinde (örn. transition mapping'de işleyip aynı pipeline'da sonra da kullanacaksanız) kullanın.
+
+- **Data**: Orijinal transition istek gövdesi (dynamic).
+- **Header**: Orijinal transition istek başlıkları (anahtarlar küçük harf).
+
+```csharp
+// Mapping'de orijinal transition isteğini okuma
+var transitionBody = context.CurrentTransition.Data;
+var authHeader = context.CurrentTransition.Header?.authorization;
+```
+
 ## ScriptResponse Sınıfı
 
 `ScriptResponse`, mapping interface'lerinden dönen standart response modelidir. Task audit data'sı, instance merge data'sı ve metadata bilgilerini taşır.

--- a/doc/tr/flow/rule-based-view-selection.md
+++ b/doc/tr/flow/rule-based-view-selection.md
@@ -1,0 +1,193 @@
+# Kural Tabanlı View Seçimi
+
+## Genel Bakış
+
+Kural tabanlı view seçimi, çalışma zamanı koşullarına göre farklı view'ların dinamik olarak seçilmesini sağlar. Bu özellik, iş akışı mantığını değiştirmeden platforma özel arayüzler, role dayalı view'lar ve koşullu UI render'ı sunar.
+
+## Kullanım Alanları
+
+- **Platforma özel view'lar**: iOS, Android ve Web istemcileri için farklı view'lar gösterme
+- **Role dayalı view'lar**: Kullanıcı rollerine göre farklı arayüzler sunma
+- **Koşullu UI**: Instance verisi veya state'e göre view render etme
+- **A/B Testi**: Deney koşullarına göre farklı view'lar sunma
+
+## JSON Şeması
+
+`views` özelliği view girişlerinden oluşan bir dizi kabul eder. Her girişte, ne zaman seçileceğini belirleyen isteğe bağlı bir `rule` bulunabilir.
+
+```json
+{
+  "views": [
+    {
+      "rule": {
+        "location": "inline",
+        "code": "using System.Threading.Tasks;\nusing BBT.Workflow.Scripting;\npublic class ViewIosRule : IConditionMapping\n{\n    public async Task<bool> Handler(ScriptContext context)\n    {\n        try\n        {\n            if (context.Headers?[\"x-platform\"] == \"ios\")\n            {\n                return true;\n            }\n            return false;\n        }\n        catch (Exception ex)\n        {\n            return false;\n        }\n    }\n}",
+        "encoding": "NAT"
+      },
+      "view": {
+        "domain": "my-domain",
+        "key": "ios-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true,
+      "extensions": ["ext1", "ext2"]
+    },
+    {
+      "view": {
+        "domain": "my-domain",
+        "key": "default-view",
+        "version": "1.0.0",
+        "flow": "sys-views"
+      },
+      "loadData": true
+    }
+  ]
+}
+```
+
+## ViewEntry Özellikleri
+
+| Özellik | Tip | Zorunlu | Açıklama |
+|---------|-----|---------|----------|
+| `rule` | ScriptCode | Hayır | Koşullu değerlendirme için IConditionMapping uygulayan C# script. Yoksa varsayılan olarak kullanılır. |
+| `view` | Reference | Evet | Yüklenecek view bileşenine referans. |
+| `loadData` | boolean | Hayır | View ile birlikte instance verisi yüklensin mi. Varsayılan: false. |
+| `extensions` | string[] | Hayır | Bu view seçildiğinde çalıştırılacak extension listesi. |
+
+### Rule (ScriptCode) Özellikleri
+
+| Özellik | Tip | Zorunlu | Açıklama |
+|---------|-----|---------|----------|
+| `location` | string | Hayır | Script konumu. Gömülü kod için `"inline"` kullanın. |
+| `code` | string | Evet | IConditionMapping arayüzünü uygulayan C# kodu. |
+| `encoding` | string | Hayır | Düz metin için `"NAT"`, Base64 için `"B64"`. |
+
+### View (Reference) Özellikleri
+
+| Özellik | Tip | Zorunlu | Açıklama |
+|---------|-----|---------|----------|
+| `domain` | string | Evet | View'ın kayıtlı olduğu domain. |
+| `key` | string | Evet | View'ın benzersiz anahtarı. |
+| `version` | string | Evet | View sürümü (semver formatı). |
+| `flow` | string | Evet | Flow tipi, genelde `"sys-views"`. |
+
+## Kural Değerlendirmesi
+
+### Değerlendirme Sırası
+
+1. View'lar **dizi sırasına** göre değerlendirilir (baştan sona)
+2. **İlk eşleşen kural** kazanır ve o view döner
+3. **Kuralı olmayan** bir giriş varsayılan/fallback olarak kullanılır
+4. Varsayılan view'ı her zaman dizinin **sonuna** koyun
+
+### Kullanılabilir ScriptContext Özellikleri
+
+`Handler` metodu içinde `ScriptContext` ile şunlara erişebilirsiniz:
+
+| Özellik | Tip | Açıklama |
+|---------|-----|----------|
+| `context.Headers` | Dictionary | HTTP istek başlıkları |
+| `context.QueryParameters` | Dictionary | URL query parametreleri |
+| `context.Instance.Data` | dynamic | Mevcut instance verisi |
+| `context.Instance.Key` | string | Instance anahtarı |
+| `context.State` | string | Mevcut state anahtarı |
+| `context.Transition` | string | Mevcut transition anahtarı (varsa) |
+| `context.CurrentTransition.Data` | dynamic | Orijinal transition istek gövdesi (v0.0.37+) |
+| `context.CurrentTransition.Header` | dynamic | Orijinal transition istek başlıkları (v0.0.37+) |
+
+## Örnekler
+
+### Örnek 1: Platforma Göre View Seçimi
+
+`x-platform` başlığına göre farklı view'lar seçme:
+
+```json
+{
+  "key": "checkout-state",
+  "stateType": 1,
+  "views": [
+    {
+      "rule": { "location": "inline", "code": "...", "encoding": "NAT" },
+      "view": { "domain": "ecommerce", "key": "checkout-ios", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    },
+    {
+      "rule": { "location": "inline", "code": "...", "encoding": "NAT" },
+      "view": { "domain": "ecommerce", "key": "checkout-android", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    },
+    {
+      "view": { "domain": "ecommerce", "key": "checkout-web", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    }
+  ]
+}
+```
+
+### Örnek 2: Role Göre View Seçimi
+
+Instance verisindeki kullanıcı rolüne göre farklı view'lar gösterme:
+
+```json
+{
+  "key": "approval-state",
+  "stateType": 2,
+  "views": [
+    {
+      "rule": { "location": "inline", "code": "...", "encoding": "NAT" },
+      "view": { "domain": "hr", "key": "approval-admin-view", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true,
+      "extensions": ["adminActions"]
+    },
+    {
+      "view": { "domain": "hr", "key": "approval-default-view", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    }
+  ]
+}
+```
+
+### Örnek 3: Transition View'ları
+
+Aynı `views` dizi formatı transition'larda da kullanılabilir:
+
+```json
+{
+  "key": "submit-transition",
+  "target": "review-state",
+  "triggerType": 0,
+  "views": [
+    {
+      "rule": { "location": "inline", "code": "...", "encoding": "NAT" },
+      "view": { "domain": "forms", "key": "submit-mobile-view", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    },
+    {
+      "view": { "domain": "forms", "key": "submit-desktop-view", "version": "1.0.0", "flow": "sys-views" },
+      "loadData": true
+    }
+  ]
+}
+```
+
+## En İyi Uygulamalar
+
+1. **Her zaman varsayılan view ekleyin**: Kuralı olmayan bir girişi dizinin sonuna fallback olarak koyun.
+2. **Kuralları özelden genele sıralayın**: Daha özel kurallar önce gelsin.
+3. **Kuralları basit tutun**: Karmaşık mantık extension veya backend servislerinde olmalı.
+4. **Anlamlı view anahtarları kullanın**: View'ları açıklayıcı adlandırın (örn. `checkout-ios`, `approval-admin-view`).
+5. **Tüm yolları test edin**: Her kural yolunun uygun koşullarla test edildiğinden emin olun.
+
+## Hata Yönetimi
+
+- Hiçbir kural eşleşmez ve varsayılan view yoksa hata döner
+- Başarısız kural değerlendirmesi loglanır ve sonraki kurala geçilir
+- Geçersiz kural sözdizimi kuralın başarısız olmasına neden olur (sonrakine devam edilir)
+
+## İlgili Dokümantasyon
+
+- [View Yönetimi](./view.md) - View tanımı ve referans şeması
+- [Function API'leri](./function.md) - View function endpoint ve seçim mantığı
+- [Instance Filtreleme](./instance-filtering.md) - Query parametre kullanımı
+- [Mapping Rehberi](./mapping.md) - ScriptContext ve mapping arayüzleri

--- a/doc/tr/flow/schema.md
+++ b/doc/tr/flow/schema.md
@@ -163,6 +163,29 @@ Task'lara gönderilen ve dönen verilerin doğrulanması:
 
 Kullanıcı arayüzünden gelen form verilerinin doğrulanması.
 
+### 5. Master Schema (Flow Seviyesi) (v0.0.37+)
+
+Bir flow, instance'ın tüm yaşam döngüsü boyunca tüm instance verisini doğrulayan bir **master şema** referansı tanımlayabilir. Flow seviyesinde master şema tanımlandığında, instance verisine yapılan her yazma bu şemaya göre doğrulanır; doğrulama başarısız olursa instance durdurulur.
+
+**Flow seviyesi tanım:**
+
+```json
+{
+  "schema": {
+    "key": "token-master",
+    "domain": "morph-idm",
+    "version": "1.0.0",
+    "flow": "sys-schemas"
+  }
+}
+```
+
+**Davranış:**
+
+- Bir flow'da `schema` referansı varsa, instance verisine eklenen tüm veri (transition'lar, task'lar, mapping'ler vb.) referans verilen şemaya göre doğrulanır.
+- Geçersiz veri instance'ın sonlandırılmasına (örn. faulted veya durdurulma) neden olur.
+- Instance verisinin tek ve tutarlı bir yapıda kalması gereken flow'larda (örn. token veya kimlik verisi) kullanılır.
+
 ## Type Değerleri
 
 `attributes.type` özelliği, schema'nın hangi bileşen türü için tasarlandığını belirtir:

--- a/doc/tr/flow/view.md
+++ b/doc/tr/flow/view.md
@@ -12,6 +12,7 @@ View'lar, workflow state'leri ve transition'ları için görsel arayüzü temsil
 6. [Platform Override'ları](#platform-overrideları)
 7. [Kullanım Örnekleri](#kullanım-örnekleri)
 8. [En İyi Uygulamalar](#en-iyi-uygulamalar)
+9. [İlgili Dokümantasyon](#ilgili-dokümantasyon)
 
 ## View Tanımı
 
@@ -57,6 +58,63 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
 - HTML şablonları
 - Bileşen referansları
 - Özel UI tanımları
+
+### View Tipleri (ViewType)
+
+Desteklenen view içerik tipleri:
+
+| Değer | Açıklama |
+|-------|----------|
+| `Json` (1) | JSON içerik (örn. form tanımları) |
+| `Html` (2) | HTML içerik |
+| `Markdown` (3) | Markdown içerik |
+| `DeepLink` (4) | Navigasyon için deep link URL (örn. uygulama şeması) |
+| `Http` (5) | HTTP URL (örn. harici veya uygulama içi web) |
+| `URN` (6) | Platform flow/transition/continue komutları için URN |
+
+**Http**, **DeepLink** ve **URN** tipleri için içerik, ileride genişletilebilmesi amacıyla aşağıdaki yapıda bir JSON nesnesi olmalıdır:
+
+**Http** – isteğe bağlı binding ile harici veya web URL:
+
+```json
+{
+  "href": "https://example.com/sayfa?s=${param}"
+}
+```
+
+**DeepLink** – isteğe bağlı binding ile uygulama deep link’i (örn. özel şema):
+
+```json
+{
+  "href": "on-burgan://onboarding/${param}"
+}
+```
+
+**URN** – isteğe bağlı binding ile platform komut URN’i:
+
+```json
+{
+  "urn": "urn:vnext:flow:continue:credit:overdraft-utilization-subprocess:${utilizationId}"
+}
+```
+
+#### URN Yapısı
+
+Format: `URN:NAMESPACE:TYPE:COMMAND:DOMAIN:FLOW:INSTANCE:TRANSITION`
+
+| Komut | Örnek | Açıklama |
+|-------|-------|----------|
+| **start** | `urn:vnext:flow:start:credit:utilization-flow` | Bir flow başlatılır ve o flow’a yönlendirilir. |
+| **transition** | `urn:vnext:flow:transition:credit:utilization-flow:39484-38484-3938d:submit` | Bir instance üzerinde transition çağrılır (kullanıcı yönlendirmesi yok). |
+| **continue** | `urn:vnext:flow:continue:credit:utilization-flow:39484-38484-3938d` | Bir instance’ta ilerleme; state alınır ve ilerlemek için view gerekir. |
+
+- **Start**: Bir flow başlatılır ve kullanıcı o flow’a yönlendirilir.
+- **Transition**: Verilen bir instance üzerinde kullanıcı arayüzü olmadan transition çalıştırılır.
+- **Continue**: Instance’ta ilerlemek için kullanılır; client state alıp view’ı yükleyerek devam eder (view zorunludur).
+
+#### Veri Bağlama (Data Binding)
+
+`href` veya `urn` içeriğinde `${param}` ifadesi kullanın. Değişken, client’ta instance verisi ve extension verisinin tek bir root’ta birleştiği yapıdan çözülür; bağlama için yalnızca root seviye özellikler desteklenir.
 
 ### Display Özelliği
 
@@ -595,5 +653,6 @@ Bu, hızlı erişim sağlar ve veritabanı yükünü azaltır.
 - [State Yönetimi](./state.md) - Workflow state'lerini anlama
 - [Transition Yönetimi](./transition.md) - Transition'larla çalışma
 - [Function API'leri](./function.md) - View function endpoint detayları
+- [Kural Tabanlı View Seçimi](./rule-based-view-selection.md) - Kurallara göre dinamik view seçimi (platform, rol, veri)
 - [Interface Dokümantasyonu](./interface.md) - Mapping interface'leri
 

--- a/release/RELEASE-NOTES-v0.0.37.md
+++ b/release/RELEASE-NOTES-v0.0.37.md
@@ -1,0 +1,314 @@
+# vNext Runtime Platform - Release Notes v0.0.37
+**Release Date:** February 17, 2026
+
+## Overview
+This release adds Master Schema validation for workflow definitions, CurrentTransition in ScriptContext for transition data access in mappings, a full Authorization mechanism (roles and queryRoles) with permissions and authorize endpoints, and OrderBy support for instance queries. It also includes bug fixes for status/state filtering, function execution validation, and GroupBy with filter support (with a breaking change: filter array format removed).
+
+---
+
+## Features
+
+### 1. Master Schema for Workflow Definitions
+
+Flow definitions can reference a **master schema** that validates all instance data throughout the instance lifecycle. When a master schema is defined, every write to instance data is validated against it; if validation fails, the instance is stopped.
+
+**Flow definition example:**
+
+```json
+{
+    "schema": {
+        "key": "token-master",
+        "domain": "morph-idm",
+        "version": "1.0.0",
+        "flow": "sys-schemas"
+    }
+}
+```
+
+**Behavior:**
+- If a flow has a master schema reference, all data added to instance data during the instance lifetime is validated against that schema.
+- Invalid data causes the instance to be terminated.
+
+> **Reference:** [#110 - Master Schema for Workflow Definitions](https://github.com/burgan-tech/vnext/issues/110)
+
+---
+
+### 2. CurrentTransition Property on ScriptContext
+
+Input and transition mappings can now access the **original transition request** (body and headers) via `ScriptContext.CurrentTransition`. This allows using transition data in mappings without writing it to instance data.
+
+**Usage:**
+
+```csharp
+context.CurrentTransition.Data   // dynamic - original transition request body
+context.CurrentTransition.Header // dynamic - original transition request headers (lowercase keys)
+```
+
+Use transition mapping to process data you do not want in instance data; the original transition payload remains available via `CurrentTransition` for the rest of the mapping pipeline.
+
+> **Reference:** [#385 - Add CurrentTransition property to ScriptContext](https://github.com/burgan-tech/vnext/issues/385)
+
+---
+
+### 3. Authorization Mechanism (Roles and QueryRoles)
+
+Function, flow, state, and transition definitions support **roles** and **queryRoles** for authorization. The following system function endpoints expose permissions and authorization checks.
+
+**Function definition with roles:**
+
+```json
+{
+  "name": "calculateFee",
+  "roles": [
+    { "role": "morph-idm.maker", "grant": "allow" },
+    { "role": "morph-idm.viewer", "grant": "allow" }
+  ]
+}
+```
+
+**Transition roles:**
+
+```json
+{
+  "key": "submit",
+  "target": "pending",
+  "roles": [
+    { "role": "morph-idm.maker", "grant": "allow" },
+    { "role": "morph-idm.initiator", "grant": "allow" }
+  ]
+}
+```
+
+**Flow and state queryRoles:**
+
+```json
+{
+  "workflow": "payment-approval",
+  "queryRoles": [
+    { "role": "morph-idm.viewer", "grant": "allow" }
+  ],
+  "states": [
+    {
+      "key": "draft",
+      "queryRoles": [
+        { "role": "morph-idm.maker", "grant": "allow" },
+        { "role": "morph-idm.viewer", "grant": "deny" }
+      ]
+    },
+    {
+      "key": "approved",
+      "type": "finish",
+      "queryRoles": []
+    }
+  ]
+}
+```
+
+**Endpoints:**
+
+| Endpoint | Description |
+|----------|-------------|
+| **Get Flow Permissions** | Returns roles and queryRoles defined for the flow. |
+| **Get Instance Permissions** | Same as flow; when the instance is in a subflow, returns the subflow’s permissions. |
+| **Flow Authorize** | Checks transition/function roles for the flow (by transition key or function key and role). |
+| **Instance Authorize** | Same as flow; with `queryRoles=true`, checks flow and state queryRoles for the instance’s current state (or subflow instance). |
+
+**Get Flow Permissions**
+
+```http
+GET /api/v1/core/workflows/account-opening/functions/permissions
+```
+
+**Example response:**
+
+```json
+{
+    "workflow": "account-opening",
+    "queryRoles": [
+        { "role": "morph-idm.viewer", "grant": "allow" }
+    ],
+    "states": [
+        { "key": "account-type-selection", "queryRoles": [] },
+        {
+            "key": "account-details-input",
+            "queryRoles": [
+                { "role": "morph-idm.maker", "grant": "allow" },
+                { "role": "morph-idm.viewer", "grant": "deny" }
+            ]
+        }
+    ],
+    "transitions": [
+        { "key": "initiate-account-opening", "target": "account-type-selection", "roles": [] },
+        {
+            "key": "select-demand-deposit",
+            "target": "account-details-input",
+            "roles": [
+                { "role": "morph-idm.maker", "grant": "allow" },
+                { "role": "morph-idm.initiator", "grant": "allow" }
+            ]
+        }
+    ],
+    "functions": []
+}
+```
+
+**Get Instance Permissions**
+
+```http
+GET /api/v1/core/workflows/account-opening/instances/{instanceId}/functions/permissions
+```
+
+Returns the same structure as Get Flow Permissions; for instances in a subflow, returns the active subflow’s permissions.
+
+**Flow Authorize**
+
+Checks whether the given role is allowed for the given transition (or function) on the flow. Optional `version`; if omitted, latest is used.
+
+```http
+GET /api/v1/core/workflows/account-opening/functions/authorize?transitionKey=submit-account-details&role=morph-idm.maker&version=1.0.0
+```
+
+**Response 200:**
+
+```json
+{ "allowed": true }
+```
+
+**Response 403:**
+
+```json
+{ "allowed": false }
+```
+
+**Instance Authorize**
+
+```http
+GET /api/v1/core/workflows/account-opening/instances/{instanceId}/functions/authorize?queryRoles=true&role=morph-idm.viewer
+```
+
+Same response shape as Flow Authorize. With `queryRoles=true`, permission is evaluated against the instance’s current state (and flow/state queryRoles); for subflows, the active subflow instance is used.
+
+**Authorize query parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `role` | Role to check. |
+| `version` | Optional. Flow version; default is latest. |
+| `transitionKey` | Transition to check (transition-level roles). |
+| `functionKey` | Function to check (function-level roles). |
+| `queryRoles` | When true, check flow and state queryRoles for the instance’s current state (and subflow context if applicable). |
+
+> **Reference:** [#382 - Authorization Mechanism](https://github.com/burgan-tech/vnext/issues/382)
+
+---
+
+### 4. OrderBy Support for Instance Queries
+
+Instance list and data endpoints support **sorting** via `sort` or `orderBy` query parameters.
+
+**Single field:**
+
+```
+?sort={"field":"createdAt","direction":"desc"}
+?orderBy={"field":"status","direction":"asc"}
+```
+
+**Multiple fields:**
+
+```
+?sort={"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}
+```
+
+- **direction:** `"asc"` or `"desc"` (case-insensitive). Defaults to `"asc"` if omitted.
+
+**Sortable fields:**
+
+| Field | Notes |
+|-------|-------|
+| `createdAt` | Creation timestamp |
+| `modifiedAt` | Modification timestamp |
+| `completedAt` | Completion timestamp |
+| `status` | Instance status |
+| `key` | Instance key |
+| `currentState` / `state` | Current state (`state` is alias) |
+| `attributes.fieldName` | JSON path into instance data; nested paths supported (e.g. `attributes.nested.path`) |
+
+Instance columns are applied in the database; `attributes.*` ordering uses the latest instance data JSON and is subject to the same schema/security as filtering.
+
+> **Reference:** [#381 - Order By Support Implementation](https://github.com/burgan-tech/vnext/issues/381)
+
+---
+
+## Bug Fixes
+
+### 1. Status and State Filter
+
+Filtering on `status` and `state` (currentState) now works correctly in instance queries.
+
+> **Reference:** [#389 - Filter status property not working](https://github.com/burgan-tech/vnext/issues/389)
+
+---
+
+### 2. Function Execution Validation
+
+The runtime now validates that a function is defined in the workflow’s functions collection before execution. Executing an undefined function returns an error.
+
+> **Reference:** [#180 - Function execution should validate function is defined in workflow's functions collection](https://github.com/burgan-tech/vnext/issues/180)
+
+---
+
+### 3. GroupBy and Filter Together (Breaking Change)
+
+GroupBy and filter can now be used together in the same query. As part of this fix, the filter format has been standardized and the previous array form is no longer supported.
+
+**Breaking change:**
+
+- **Before:** `"filter": ["expr1", "expr2"]` (array) was supported.
+- **After:** Only a single expression is supported: `"filter": "expr"` (string). The GraphQL-style filter format is now the single standard.
+
+If you currently pass `filter` as an array, update to a single expression (e.g. combine conditions with `and`/`or` in one expression).
+
+> **Reference:** [#392 - GroupBy and Filtering queries not working together](https://github.com/burgan-tech/vnext/issues/392)
+
+---
+
+## Configuration Updates
+
+Configuration for v0.0.37:
+
+```json
+{
+  "runtimeVersion": "0.0.37",
+  "schemaVersion": "0.0.36"
+}
+```
+
+> **Note:** Schema version remains at 0.0.36; runtime v0.0.37 is backward compatible with schema v0.0.36.
+
+---
+
+## Issues Referenced
+
+- [#110 - Master Schema for Workflow Definitions](https://github.com/burgan-tech/vnext/issues/110)
+- [#385 - Add CurrentTransition property to ScriptContext](https://github.com/burgan-tech/vnext/issues/385)
+- [#382 - Authorization Mechanism](https://github.com/burgan-tech/vnext/issues/382)
+- [#381 - Order By Support Implementation](https://github.com/burgan-tech/vnext/issues/381)
+- [#389 - Filter status property not working](https://github.com/burgan-tech/vnext/issues/389)
+- [#180 - Function execution should validate function is defined in workflow's functions collection](https://github.com/burgan-tech/vnext/issues/180)
+- [#392 - GroupBy and Filtering queries not working together](https://github.com/burgan-tech/vnext/issues/392)
+
+---
+
+## Summary
+
+With this release:
+- Master Schema validates all instance data for flows that reference it; invalid data stops the instance.
+- ScriptContext.CurrentTransition provides access to the original transition body and headers in mappings.
+- Authorization supports roles and queryRoles on functions, flows, states, and transitions, with permissions and authorize endpoints.
+- Instance queries support OrderBy/sort with single or multiple fields and a defined set of sortable fields.
+- Status and state filtering works correctly; function execution is validated against the workflow’s functions; GroupBy and filter work together, with filter standardized to a single expression (breaking change for filter array usage).
+
+---
+
+**vNext Runtime Platform Team**  
+February 17, 2026


### PR DESCRIPTION
## Summary
Adds release notes for v0.0.37 and updates documentation (EN/TR) per ai-docs/v37.md.

## Changes
- **Release:** `release/RELEASE-NOTES-v0.0.37.md` — Master Schema (#110), CurrentTransition (#385), Authorization (#382), OrderBy (#381), bug fixes (#389, #180, #392) and config
- **Rule-based view:** `doc/en/flow/rule-based-view-selection.md`, `doc/tr/flow/rule-based-view-selection.md`; links from view.md and function.md
- **view.md (EN/TR):** ViewType enum, Http/DeepLink/URN content format, URN structure, data binding
- **function.md (EN/TR):** Rule-based view in view selection logic, Authorization section (permissions, authorize endpoints)
- **instance-filtering.md (EN/TR):** OrderBy/sort section, filter breaking change note, status/state filter fix note
- **schema.md (EN/TR):** Master Schema (flow-level) use case
- **mapping.md (EN/TR):** ScriptContext CurrentTransition (v0.0.37+)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add v0.0.37 release notes and update English/Turkish workflow documentation for views, authorization, filtering, schemas, and mappings.

New Features:
- Document rule-based view selection using views arrays with ScriptContext-based rules (EN/TR).
- Describe new Authorization capabilities with roles/queryRoles and permissions/authorize endpoints in function APIs (EN/TR).
- Explain new ViewType options and structured content formats for Http, DeepLink, and URN view content, including URN structure and data binding (EN/TR).
- Introduce Master Schema (flow-level) usage for validating instance data across a workflow’s lifecycle (EN/TR).
- Document CurrentTransition access in ScriptContext for transition request body and headers in mappings (EN/TR).
- Describe OrderBy/sort support for instance queries via sort/orderBy parameters and sortable fields (EN/TR).

Bug Fixes:
- Note corrected behavior for filtering by status and state in instance queries (EN/TR).

Enhancements:
- Clarify view function selection logic to prioritize rule-based views before legacy single-view logic (EN/TR).

Documentation:
- Add comprehensive release notes file for v0.0.37 covering features, bug fixes, configuration, and breaking changes.
- Highlight breaking change to instance filtering: filter must be a single expression instead of an array, with guidance on combining conditions (EN/TR).
- Explain that GroupBy and filtering now work together with standardized single-expression filters, noting the breaking change in the release notes.