### PR TITLE
v0.0.40 release documents updated

### DIFF
--- a/doc/en/flow/function.md
+++ b/doc/en/flow/function.md
@@ -295,6 +295,34 @@ Content-Type: application/json
 }
 ```
 
+#### Authorization-aware ETag (v0.0.40+)
+
+When the data endpoints use authorization, the response can vary per caller. From v0.0.40 the ETag strategy distinguishes:
+
+- **etag** — Changes when the **response** (or request context, e.g. authorization) changes. Use for general response caching and `If-None-Match` conditional requests.
+- **entityETag** — Changes when the **entity data** changes. Use to detect actual data changes (e.g. for sync or invalidation).
+
+Both values appear in the response body and in headers:
+
+| Body field     | Response header   | Meaning                |
+|----------------|-------------------|------------------------|
+| `etag`         | `ETag`            | Response/request change |
+| `entityEtag`   | `X-Entity-ETag`   | Entity data change      |
+
+**Example response body:**
+```json
+{
+  "etag": "\"Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8\"",
+  "entityEtag": "\"01KK8Q8N5T6H49T8AENYT6Z6ZQ\""
+}
+```
+
+**Example response headers:**
+```http
+ETag: "Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8"
+X-Entity-ETag: "01KK8Q8N5T6H49T8AENYT6Z6ZQ"
+```
+
 ### Extensions
 
 Extensions provide additional context data that enriches the instance data:

--- a/doc/en/flow/schema.md
+++ b/doc/en/flow/schema.md
@@ -72,7 +72,7 @@ A Schema is a domain entity that defines the structure of input and output data 
 | `version` | `string` | Version information (semantic versioning) |
 | `domain` | `string` | Domain the schema belongs to |
 | `flow` | `string` | Flow stream information (default: `sys-schemas`) |
-| `flowVersion` | `string` | Flow version information |
+| `flowVersion` | `string` | Flow version information (required in definition schemas since v0.0.40) |
 | `tags` | `string[]` | Tags for categorization and searching |
 | `attributes` | `object` | Schema content and metadata |
 

--- a/doc/en/flow/tasks/dapr-service.md
+++ b/doc/en/flow/tasks/dapr-service.md
@@ -48,7 +48,7 @@ Dapr Service Task is a task type used to make calls to microservices using the D
 
 ### Fields
 
-The following fields are defined in the config section of DAPR Service Task:
+The following fields are defined in the config section of DAPR Service Task. The task definition requires a `config` section (v0.0.40+).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/doc/en/flow/tasks/http-task.md
+++ b/doc/en/flow/tasks/http-task.md
@@ -47,7 +47,7 @@ HTTP Task is a task type used to send HTTP requests to external web services. Wi
 
 ### Fields
 
-The following fields are defined in the config section of HTTP Task:
+The following fields are defined in the config section of HTTP Task. The task definition requires a `config` section (v0.0.40+).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/doc/en/flow/tasks/trigger-task.md
+++ b/doc/en/flow/tasks/trigger-task.md
@@ -872,6 +872,8 @@ Required fields for tasks can be provided in **two ways**:
 1. **Static Configuration**: Specified in the config section of the task JSON definition
 2. **Dynamic Setting**: Set at runtime using setter methods in the InputHandler
 
+The `config` section is required in task definitions (v0.0.40+).
+
 **Priority Rule:** If the same field is defined in both JSON config and InputHandler mapping, **the value set in InputHandler takes precedence**. This allows dynamic runtime values to override static configuration.
 
 **Usage Strategies:**

--- a/doc/en/flow/view.md
+++ b/doc/en/flow/view.md
@@ -61,7 +61,7 @@ The `Content` property contains the actual UI definition. This can be:
 
 #### Type-dependent content (v0.0.39+)
 
-The view definition schema allows **content** to be **string or JSON** depending on view type: for **Json** type, content is an object or array; for **Html**, **Markdown**, and similar types, content is a string. This improves conflict handling in version control and design tools while remaining backward compatible. See also [vnext-schema #85](https://github.com/burgan-tech/vnext-schema/issues/85).
+The view definition schema allows **content** to be **string or JSON** depending on view type: for **Json** type, content is an object or array; for **Html**, **Markdown**, and similar types, content is a string. This improves conflict handling in version control and design tools while remaining backward compatible. See also [vnext-schema #85](https://github.com/burgan-tech/vnext-schema/issues/85). The View function supports JSON **content** up to a maximum depth of 256 (v0.0.40+).
 
 ### View Types (ViewType)
 

--- a/doc/tr/flow/function.md
+++ b/doc/tr/flow/function.md
@@ -295,6 +295,34 @@ Content-Type: application/json
 }
 ```
 
+#### Authorization-aware ETag (v0.0.40+)
+
+Data endpoint'leri yetkilendirme kullandığında yanıt çağırana göre değişebilir. v0.0.40 itibarıyla ETag stratejisi şöyle ayrılır:
+
+- **etag** — **Yanıt** (veya istek bağlamı, örn. yetkilendirme) değiştiğinde değişir. Genel yanıt önbelleği ve `If-None-Match` koşullu istekler için kullanın.
+- **entityETag** — **Entity verisi** değiştiğinde değişir. Gerçek veri değişimini (örn. senkronizasyon veya invalidation) tespit etmek için kullanın.
+
+Her iki değer hem response body'de hem header'larda yer alır:
+
+| Body alanı     | Response header   | Anlamı                    |
+|----------------|-------------------|---------------------------|
+| `etag`         | `ETag`            | Yanıt/istek değişimi      |
+| `entityEtag`   | `X-Entity-ETag`   | Entity veri değişimi      |
+
+**Örnek response body:**
+```json
+{
+  "etag": "\"Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8\"",
+  "entityEtag": "\"01KK8Q8N5T6H49T8AENYT6Z6ZQ\""
+}
+```
+
+**Örnek response header'ları:**
+```http
+ETag: "Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8"
+X-Entity-ETag: "01KK8Q8N5T6H49T8AENYT6Z6ZQ"
+```
+
 ### Extension'lar
 
 Extension'lar, instance verisini zenginleştiren ek bağlam verisi sağlar:

--- a/doc/tr/flow/schema.md
+++ b/doc/tr/flow/schema.md
@@ -72,7 +72,7 @@ Schema, workflow bileşenleri için giriş ve çıkış verilerinin yapısını 
 | `version` | `string` | Versiyon bilgisi (semantic versioning) |
 | `domain` | `string` | Schema'nın ait olduğu domain |
 | `flow` | `string` | Flow stream bilgisi (varsayılan: `sys-schemas`) |
-| `flowVersion` | `string` | Flow versiyon bilgisi |
+| `flowVersion` | `string` | Flow versiyon bilgisi (tanım şemalarında zorunlu, v0.0.40+) |
 | `tags` | `string[]` | Kategorilendirme ve arama için etiketler |
 | `attributes` | `object` | Schema içeriği ve metadata |
 

--- a/doc/tr/flow/tasks/dapr-service.md
+++ b/doc/tr/flow/tasks/dapr-service.md
@@ -51,7 +51,7 @@ Dapr Service Task, Dapr service invocation özelliği kullanarak mikroservislere
 
 ### Alanlar
 
-DAPR Service Task'ın config bölümünde aşağıdaki alanlar tanımlanır:
+DAPR Service Task'ın config bölümünde aşağıdaki alanlar tanımlanır. Task tanımında `config` zorunludur (v0.0.40+).
 
 | Alan | Tip | Varsayılan | Açıklama |
 |------|-----|------------|----------|

--- a/doc/tr/flow/tasks/http-task.md
+++ b/doc/tr/flow/tasks/http-task.md
@@ -47,7 +47,7 @@ HTTP Task, harici web servislerine HTTP istekleri göndermek için kullanılan g
 
 ### Alanlar
 
-HTTP Task'ın config bölümünde aşağıdaki alanlar tanımlanır:
+HTTP Task'ın config bölümünde aşağıdaki alanlar tanımlanır. Task tanımında `config` zorunludur (v0.0.40+).
 
 | Alan | Tip | Varsayılan | Açıklama |
 |------|-----|------------|----------|

--- a/doc/tr/flow/tasks/trigger-task.md
+++ b/doc/tr/flow/tasks/trigger-task.md
@@ -852,6 +852,8 @@ Task'lar için gerekli alanlar **iki şekilde** sağlanabilir:
 1. **Statik Konfigürasyon**: Task JSON tanımında config bölümünde belirtilir
 2. **Dinamik Ayarlama**: InputHandler içinde setter metodları ile runtime'da ayarlanır
 
+Task tanımlarında `config` alanı zorunludur (v0.0.40+).
+
 **Öncelik Kuralı:** Hem JSON config'te hem de InputHandler mapping'inde aynı alan tanımlanmışsa, **InputHandler'da set edilen değer önceliğe sahiptir**. Bu sayede runtime'da dinamik değerlerle statik konfigürasyon override edilebilir.
 
 **Kullanım Stratejileri:**

--- a/doc/tr/flow/view.md
+++ b/doc/tr/flow/view.md
@@ -61,7 +61,7 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
 
 #### Tipe bağlı içerik (v0.0.39+)
 
-View tanım şemasında **content** alanı view tipine göre **string veya JSON** kabul eder: **Json** tipi için content bir object veya array; **Html**, **Markdown** ve benzeri tipler için content bir string'dir. Bu sayede versiyon kontrolü ve tasarım araçlarında conflict yönetimi iyileşir; geriye dönük uyumluluk korunur. Ayrıca bkz. [vnext-schema #85](https://github.com/burgan-tech/vnext-schema/issues/85).
+View tanım şemasında **content** alanı view tipine göre **string veya JSON** kabul eder: **Json** tipi için content bir object veya array; **Html**, **Markdown** ve benzeri tipler için content bir string'dir. Bu sayede versiyon kontrolü ve tasarım araçlarında conflict yönetimi iyileşir; geriye dönük uyumluluk korunur. Ayrıca bkz. [vnext-schema #85](https://github.com/burgan-tech/vnext-schema/issues/85). View function'da JSON **content** için maksimum derinlik 256'dır (v0.0.40+).
 
 ### View Tipleri (ViewType)
 

--- a/release/RELEASE-NOTES-v0.0.40.md
+++ b/release/RELEASE-NOTES-v0.0.40.md
@@ -1,0 +1,108 @@
+# vNext Runtime Platform - Release Notes v0.0.40
+**Release Date:** March 10, 2026
+
+## Overview
+This release improves **schema consistency** by making **flowVersion** required in definition schemas (vnext-schema) and **config** required in task definitions, and introduces an **authorization-aware ETag strategy** for data endpoints: response body exposes **etag** (request/response change) and **entityETag** (entity data change), with corresponding **ETag** and **X-Entity-ETag** response headers. It also fixes View function handling of deep JSON **content** (max depth increased to 256, `ReferenceHandler.IgnoreCycles`) and removes an unnecessary retry block in the cache invalidation handler.
+
+---
+
+## Bug Fixes
+
+### 1. Make flowVersion a Required Field in Definition Schemas
+
+**flowVersion** is now **required** in definition schemas in vnext-schema. This aligns the schema with runtime behavior (flowVersion was already required in v0.0.39) and ensures consistency across tooling and validation.
+
+> **Reference:** [#88 - Make flowVersion a required field in definition schemas](https://github.com/burgan-tech/vnext-schema/issues/88)
+
+---
+
+### 2. Make config a Required Field in Task Definitions
+
+Task definitions now **require** a **config** section. The task-definition schema (task-definition.schema.json) has been updated so that `config` is mandatory, ensuring all task definitions carry explicit configuration and improving consistency.
+
+> **Reference:** [#89 - Make config a required field in task-definition.schema.json](https://github.com/burgan-tech/vnext-schema/issues/89)
+
+---
+
+## Tasks / Improvements
+
+### Redesign ETag Strategy for Authorization-Aware Responses
+
+After adding the authorization layer to data endpoints, response content could change per caller, and the previous ETag logic became inconsistent. The ETag strategy has been **redesigned** so that:
+
+- **etag** in the response body reflects **request/response** change (e.g. authorization or response shape).
+- **entityETag** in the response body reflects **entity data** change.
+
+Clients can use **entityETag** to track when the underlying data has changed and **etag** for general response caching. The same values are exposed in response headers:
+
+- **ETag** — matches the `etag` value (without surrounding quotes in the header).
+- **X-Entity-ETag** — matches the `entityETag` value.
+
+**Example response body:**
+```json
+{
+  "etag": "\"Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8\"",
+  "entityEtag": "\"01KK8Q8N5T6H49T8AENYT6Z6ZQ\""
+}
+```
+
+**Example response headers:**
+```http
+ETag: "Hko5JI4fDcAOOnf-KGFNA7Xo_MpuxcLl1_hg5j2Sua8"
+X-Entity-ETag: "01KK8Q8N5T6H49T8AENYT6Z6ZQ"
+```
+
+> **Reference:** [#448 - Redesign ETag Strategy for Authorization-Aware Responses](https://github.com/burgan-tech/vnext/issues/448)
+
+---
+
+## Other
+
+### View Function: Deep JSON Content and ReferenceHandler
+
+An error occurred when the **content** field of a view contained JSON deeper than the default maximum depth (32). The maximum depth has been increased to **256**, and **ReferenceHandler** has been set to **IgnoreCycles** so that deeply nested or cyclic structures in view content are handled correctly.
+
+---
+
+### Cache Invalidation Handler: Retry Behavior
+
+An unnecessary retry block in the cache invalidation handler was removed, so retries are no longer incorrectly prevented when appropriate.
+
+---
+
+## Configuration Updates
+
+Configuration for v0.0.40:
+
+```json
+{
+  "runtimeVersion": "0.0.40",
+  "schemaVersion": "0.0.38"
+}
+```
+
+> **Note:** Schema version **0.0.38** is used with this runtime version. Ensure your configuration and tooling reference the updated schema.
+
+---
+
+## Issues Referenced
+
+- [#88 - Make flowVersion a required field in definition schemas](https://github.com/burgan-tech/vnext-schema/issues/88)
+- [#89 - Make config a required field in task-definition.schema.json](https://github.com/burgan-tech/vnext-schema/issues/89)
+- [#448 - Redesign ETag Strategy for Authorization-Aware Responses](https://github.com/burgan-tech/vnext/issues/448)
+
+---
+
+## Summary
+
+With this release:
+
+- **Definition schemas** (vnext-schema) require **flowVersion**; **task definitions** require **config**.
+- **Data endpoints** use an **authorization-aware ETag** strategy: **etag** and **entityETag** in the response body, with **ETag** and **X-Entity-ETag** response headers for consistent caching and change detection.
+- **View function** supports deeper JSON **content** (max depth 256) with **ReferenceHandler.IgnoreCycles**.
+- **Cache invalidation handler** retry behavior is corrected.
+
+---
+
+**vNext Runtime Platform Team**  
+March 10, 2026


### PR DESCRIPTION
## Summary by Sourcery

Document changes for the v0.0.40 release, covering new ETag behavior, stricter schema and task definition requirements, view content limits, and associated release notes.

Documentation:
- Describe authorization-aware ETag behavior with separate response and entity ETags in both English and Turkish function documentation.
- Clarify that flow schemas require the flowVersion field in definition schemas (v0.0.40+) in both English and Turkish docs.
- State that task definitions now require a config section for Dapr Service, HTTP Task, and Trigger Task documentation in both English and Turkish.
- Document the View function’s JSON content maximum depth of 256 (v0.0.40+) in both English and Turkish view docs.

Chores:
- Add detailed v0.0.40 release notes summarizing schema requirements, ETag strategy, view handling changes, cache invalidation behavior, and runtime/schema versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Authorization-aware ETag documentation detailing new etag and entityETag response strategies.
  * Updated schema requirements to reflect flowVersion as mandatory.
  * Clarified that config sections are now required in task definitions.
  * Documented JSON content depth constraints for view types.
  * Released v0.0.40 release notes covering schema and API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->